### PR TITLE
Bugfix

### DIFF
--- a/.github/workflows/publish-to-auto-release.yml
+++ b/.github/workflows/publish-to-auto-release.yml
@@ -59,13 +59,12 @@ jobs:
         run: pnpm install # change this to npm, pnpm or bun depending on which one you use.
       
       - name: Create signing key file
-        if: env.TAURI_SIGNING_PRIVATE_KEY
-        run: echo "${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}" > signing_key.key
+        run: echo "${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}" > ${{ github.workspace }}/sign_private_key.key
 
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_SIGNING_PRIVATE_KEY: signing_key.key
+          TAURI_SIGNING_PRIVATE_KEY: ${{ github.workspace }}/sign_private_key.key
         with:
           tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
           releaseName: "App v__VERSION__"


### PR DESCRIPTION
Updated the publish-to-auto-release workflow to create the signing key file in the GitHub workspace directory. This change ensures the signing key is correctly referenced during the Tauri action execution.