### PR TITLE
Refactor publish-to-auto-release workflow

### DIFF
--- a/.github/workflows/publish-to-auto-release.yml
+++ b/.github/workflows/publish-to-auto-release.yml
@@ -58,13 +58,11 @@ jobs:
       - name: install frontend dependencies
         run: pnpm install # change this to npm, pnpm or bun depending on which one you use.
       
-      - name: Create signing key file
-        run: echo "${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}" > ${{ github.workspace }}/sign_private_key.key
 
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ github.workspace }}/sign_private_key.key
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
         with:
           tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
           releaseName: "App v__VERSION__"


### PR DESCRIPTION
Refactor publish-to-auto-release workflow to directly use the Tauri signing private key from secrets, removing the need to create a signing key file. This simplifies the workflow and enhances security by avoiding file creation.