### PR TITLE
Enhance security

### DIFF
--- a/.github/workflows/publish-to-auto-release.yml
+++ b/.github/workflows/publish-to-auto-release.yml
@@ -63,6 +63,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
           releaseName: "App v__VERSION__"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -43,7 +43,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDgzQzI2NUMyQjY3OTgzM0MKUldROGczbTJ3bVhDZ3hIYlV4OGZUb0EzeFZCUHBJR3RKSll6QlltckNQSjFhWEVRcUFRK3pnMnoK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEIzNjg3Q0Q1NzYxNDNBRkEKUldUNk9oUjIxWHhvczdLdkpXTHRzTFI3Ky9HVHB0UTV3VWJZb254Y1QxREhrQUVjeGh4Z1B2Ni8K",
       "endpoints": [
         "https://github.com/Jeamee/MCPHub-Desktop/releases/latest/download/latest.json"
       ],


### PR DESCRIPTION
Enhance publish-to-auto-release workflow by adding TAURI_SIGNING_PRIVATE_KEY_PASSWORD to environment variables and update Tauri public key in configuration. This improves security and ensures proper signing during the release process.