### PR TITLE
Remove linux platform

### DIFF
--- a/.github/workflows/publish-to-auto-release.yml
+++ b/.github/workflows/publish-to-auto-release.yml
@@ -20,8 +20,6 @@ jobs:
             args: "--target aarch64-apple-darwin"
           - platform: "macos-latest" # for Intel based macs.
             args: "--target x86_64-apple-darwin"
-          - platform: "ubuntu-22.04" # for Tauri v1 you could replace this with ubuntu-20.04.
-            args: ""
           - platform: "windows-latest"
             args: ""
 


### PR DESCRIPTION
Remove Ubuntu 22.04 platform from publish-to-auto-release workflow to streamline build process and focus on macOS and Windows platforms.