### PR TITLE
bugfix v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-# Tauri + React + Typescript
+# MCPHub Desktop
 
-This template should help get you started developing with Tauri, React and Typescript in Vite.
-
-## Recommended IDE Setup
-
-- [VS Code](https://code.visualstudio.com/) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
+Coming Soo!

--- a/src-tauri/src/api/servers/core.rs
+++ b/src-tauri/src/api/servers/core.rs
@@ -68,18 +68,18 @@ pub struct ClientConfig {
 impl ClientConfig {
     fn config_path() -> std::path::PathBuf {
         #[cfg(target_os = "macos")]
-        let config_path = get_home()
+        {
+        get_home()
             .unwrap()
-            .join("Library/Application Support/Claude/claude_desktop_config.json");
+            .join("Library/Application Support/Claude/claude_desktop_config.json")
+        }
         #[cfg(target_os = "windows")]
         {
         let appdata = std::env::var("APPDATA").unwrap();
-        let config_path = std::path::PathBuf::from(appdata)
+        std::path::PathBuf::from(appdata)
             .join("Claude")
-            .join("claude_desktop_config.json");
+            .join("claude_desktop_config.json")
         }
-
-        config_path
     }
 
     fn load() -> Self {


### PR DESCRIPTION
- Changed project title in README from "Tauri + React + Typescript" to "MCPHub Desktop" and removed outdated setup instructions.
- Refactored the `config_path` function in `src-tauri/src/api/servers/core.rs` to improve readability by removing unnecessary variable assignments and ensuring consistent formatting for macOS and Windows paths.