### PR TITLE
Remove macOS configuration

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -33,15 +33,6 @@
         "language": "en-US"
       }
     },
-    "macOS": {
-        "frameworks": [],
-        "minimumSystemVersion": "10.13",
-        "exceptionDomain": "",
-        "signingIdentity": null,
-        "providerShortName": null,
-        "entitlements": null,
-        "hardenedRuntime": true
-      },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
Remove macOS configuration from tauri.conf.json to streamline project setup and focus on essential settings.