### PR TITLE
 Add macOS configuration to tauri.conf.json and update node path handling in core.rs

### DIFF
--- a/src-tauri/src/api/dependency/core.rs
+++ b/src-tauri/src/api/dependency/core.rs
@@ -31,7 +31,7 @@ impl NpmHandler {
             .unwrap_or("".to_owned());
         if !node_path.is_empty() {
             if let Ok(metadata) = fs::metadata(&node_path) {
-                if metadata.is_dir() || metadata.is_symlink() {
+                if metadata.is_dir() || metadata.is_symlink() || metadata.is_file() {
                     trace!("Node path exists: {}", node_path);
                     return Ok(true);
                 }
@@ -49,7 +49,7 @@ impl NpmHandler {
         let cmd_output = cmd!(shell, "where.exe node").quiet().read()?;
 
         trace!("Node command output: {}", cmd_output);
-        store.set("node_path", node_path);
+        store.set("node_path", cmd_output);
         store.set("use_system_node", true);
 
         Ok(true)
@@ -139,7 +139,7 @@ impl UVHandler {
 
         if !uv_path.is_empty() {
             if let Ok(metadata) = fs::metadata(&uv_path) {
-                if metadata.is_dir() || metadata.is_symlink() {
+                if metadata.is_dir() || metadata.is_symlink() || metadata.is_file() {
                     trace!("UV path exists: {}", uv_path);
                     return Ok(true);
                 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -33,6 +33,15 @@
         "language": "en-US"
       }
     },
+    "macOS": {
+      "frameworks": [],
+      "minimumSystemVersion": "10.13",
+      "exceptionDomain": "",
+      "signingIdentity": "-",
+      "providerShortName": "-",
+      "entitlements": null,
+      "hardenedRuntime": true
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
- Introduced macOS-specific settings in tauri.conf.json, including minimum system version and hardened runtime.
- Updated node path validation in core.rs to check for files in addition to directories and symlinks.
- Modified the way the node path is stored, now capturing the command output instead of the original path.